### PR TITLE
fix: sanitize commit message quotes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,6 @@ src/git_info.hpp:
 	$(call progress, Creating $@)
 	@commit_hash=$$(git rev-parse HEAD); \
 	commit_date=$$(git show -s --format=%cd --date=short $$commit_hash); \
-	commit_message=$$(git show -s --format="%s" $$commit_hash | tr -s "\"" "\'"); \
+	commit_message=$$(git show -s --format="%s" $$commit_hash | sed 's/"/\\\"/g'); \
 	echo "#define GIT_COMMIT_MESSAGE \"$$commit_message\"" > src/git_info.hpp; \
 	echo "#define GIT_COMMIT_DATE \"$$commit_date\"" >> src/git_info.hpp

--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,6 @@ src/git_info.hpp:
 	$(call progress, Creating $@)
 	@commit_hash=$$(git rev-parse HEAD); \
 	commit_date=$$(git show -s --format=%cd --date=short $$commit_hash); \
-	commit_message=$$(git show -s --format=%s $$commit_hash); \
+	commit_message=$$(git show -s --format="%s" $$commit_hash | tr -s "\"" "\'"); \
 	echo "#define GIT_COMMIT_MESSAGE \"$$commit_message\"" > src/git_info.hpp; \
 	echo "#define GIT_COMMIT_DATE \"$$commit_date\"" >> src/git_info.hpp


### PR DESCRIPTION
Fixing issue #1, just replacing " to '.